### PR TITLE
Adding SHA-256 authentication capabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ LABEL org.opencontainers.image.url="https://github.com/Angatar/mysql-s3-backup"
 
 RUN apk upgrade --no-cache \
   &&  echo  https://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories \
-  && apk add --no-cache mysql-client ca-certificates s3cmd
+  && apk add --no-cache mysql-client mariadb-connector-c ca-certificates s3cmd
   
 WORKDIR /s3


### PR DESCRIPTION
In MySQL 8.4, caching_sha2_password is the default authentication plugin rather than mysql_native_password (deprecated).